### PR TITLE
fix: adds S3 bucket ownership controls to allow ACL attachment (#3)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,14 @@ locals {
 # S3 Bucket for codedeploy/codepipeline
 resource "aws_s3_bucket" "codepipeline_bucket" {
   bucket_prefix = "nightscout-codepipeline-"
-  tags = var.tags
+  tags          = var.tags
+}
+# Set Bucker Ownership to apply ACL
+resource "aws_s3_bucket_ownership_controls" "codepipeline_bucket_ownership" {
+  bucket = aws_s3_bucket.codepipeline_bucket.id
+  rule {
+    object_ownership = "ObjectWriter"
+  }
 }
 resource "aws_s3_bucket_acl" "codepipeline_bucket_acl" {
   bucket = aws_s3_bucket.codepipeline_bucket.id
@@ -29,9 +36,9 @@ resource "aws_s3_bucket_acl" "codepipeline_bucket_acl" {
 
 # Nightscout config in SSM
 module "ssm" {
-  source        = "./modules/ssm"
-  port          = var.port
-  tags          = local.tags
+  source = "./modules/ssm"
+  port   = var.port
+  tags   = local.tags
 }
 
 


### PR DESCRIPTION
Terraform's AWS provider expects bucket owner controls prior to attaching ACLs now. Here's [a thread](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/242) on this fairly new issue.

Closes: #3 